### PR TITLE
Protect `androidChat` from being accessed in `removeContextMenu`

### DIFF
--- a/content.js
+++ b/content.js
@@ -103,7 +103,8 @@ fetchSVGContent('word', (wordSvgContent) => {
 function removeContextMenu() {
   updateChat();
   contextMenu?.remove();
-  androidChat().removeEventListener("scroll", updateScroll)
+  if(isAndroid)
+    androidChat().removeEventListener("scroll", updateScroll);
 }
 
 function isWithin(x, y, classNames, func) {


### PR DESCRIPTION
if not `isAndroid`

to fix reference to property of `null`